### PR TITLE
This library no longer supports just one device.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Meross IoT library
 A pure-python based library providing API for controlling Meross IoT devices over the internet.
-At the moment there is only support for the **Meross Mss310** smart plug.
+
+To see what devices are currently supported, checkout the `Currently supported devices`-section. 
 Hopefully, more Meross hardware will be supported in the future.
 
 This library is still work in progress, therefore use it with caution.


### PR DESCRIPTION
With the latest changes, the README has become incorrect. I saw that you added a `Currently supported devices`-section, so it might be a good idea to update the first paragraph as well.