### PR TITLE
Add support for Meross Eenther WP110B Smart Wi-Fi Plug Mini

### DIFF
--- a/meross_iot/device_factory.py
+++ b/meross_iot/device_factory.py
@@ -1,4 +1,4 @@
-from meross_iot.supported_devices.power_plugs import Mss310, Mss110, Mss425e
+from meross_iot.supported_devices.power_plugs import Mss310, Mss110, Mss425e, Wp110b
 
 def build_wrapper(
         token,
@@ -13,5 +13,7 @@ def build_wrapper(
         return Mss110(token, key, user_id,**device_specs)
     elif device_type.lower() == "mss425e":
         return Mss425e(token, key, user_id,**device_specs)
+    elif device_type.lower() == "wp110b":
+        return Wp110b(token, key, user_id,**device_specs)
     else:
         return None

--- a/meross_iot/supported_devices/power_plugs.py
+++ b/meross_iot/supported_devices/power_plugs.py
@@ -323,7 +323,25 @@ class Device:
         self._status = False
         payload = {"channel":0,"toggle":{"onoff":0}}
         return self._execute_cmd("SET", "Appliance.Control.Toggle", payload)
-      
+
+    def turn_on_channel(self, channel):
+        return None
+
+    def turn_off_channel(self, channel):
+        return None
+
+    def get_power_consumptionX(self):
+        return None
+
+    def get_electricity(self):
+        return None
+
+    def enable_usb(self):
+        return None
+
+    def disable_usb(self):
+        return None
+
 class Mss310(Device):
     def get_power_consumptionX(self):
         return self._execute_cmd("GET", "Appliance.Control.ConsumptionX", {})
@@ -364,6 +382,25 @@ class Mss425e(Device):
 
 class Mss110(Device):
     pass
+
+class Wp110b(Device):
+    # TODO Implement for all channels
+    def _handle_toggle(self, message):
+        return None
+
+    # TODO Implement for all channels
+    def get_status(self):
+        return None
+    def get_electricity(self):
+        return self._execute_cmd("GET", "Appliance.Control.Electricity", {})
+
+    def turn_on(self):
+        payload = {'togglex':{"onoff":1}}
+        return self._execute_cmd("SET", "Appliance.Control.ToggleX", payload)
+
+    def turn_off(self):
+        payload = {'togglex':{"onoff":0}}
+        return self._execute_cmd("SET", "Appliance.Control.ToggleX", payload)
 
 class AtomicCounter(object):
     _lock = None

--- a/meross_iot/supported_devices/power_plugs.py
+++ b/meross_iot/supported_devices/power_plugs.py
@@ -391,8 +391,6 @@ class Wp110b(Device):
     # TODO Implement for all channels
     def get_status(self):
         return None
-    def get_electricity(self):
-        return self._execute_cmd("GET", "Appliance.Control.Electricity", {})
 
     def turn_on(self):
         payload = {'togglex':{"onoff":1}}


### PR DESCRIPTION
Signed-off-by: Jason Ertel <jertel@codesim.com>

Added support for the mini Wi-Fi outlets such as the one listed here:
https://www.amazon.com/Enther-Assistant-Required-Control-Anywhere/dp/B07H4VSMQS