### PR TITLE
Mss310 add hw 2.0.0 compatibility

### DIFF
--- a/meross_iot/supported_devices/power_plugs.py
+++ b/meross_iot/supported_devices/power_plugs.py
@@ -1,3 +1,5 @@
+debug = False
+
 import paho.mqtt.client as mqtt
 import ssl
 import random
@@ -38,6 +40,12 @@ class Device:
     _uuid = None
     _client_id = None
     _app_id = None
+
+    # Device informations
+    _name = None
+    _type = None
+    _hwversion = None
+    _fwversion = None
 
     # Topic name where the client should publish to its commands. Every client should have a dedicated one.
     _client_request_topic = None
@@ -89,6 +97,16 @@ class Device:
             self._domain = "eu-iot.meross.com"
         if "channels" in kwords:
             self._channels = kwords['channels']
+
+        # Informations about device
+        if "devName" in kwords:
+            self._name = kwords['devName']
+        if "deviceType" in kwords:
+            self._type = kwords['deviceType']
+        if "fmwareVersion" in kwords:
+            self._fwversion = kwords['fmwareVersion']
+        if "hdwareVersion" in kwords:
+            self._hwversion = kwords['hdwareVersion']
 
         self._generate_client_and_app_id()
 
@@ -279,7 +297,7 @@ class Device:
         try:
             return 'from' in message['header'] and message['header']['from'].split('/')[2] == self._uuid
         except:
-            return false
+            return False
 
     def _handle_toggle(self, message):
         if 'onoff' in message['payload']['toggle']:
@@ -330,6 +348,22 @@ class Mss310(Device):
 
     def get_electricity(self):
         return self._execute_cmd("GET", "Appliance.Control.Electricity", {})
+
+    def turn_on(self):
+        if self._hwversion.split(".")[0] == "2":
+            payload = {'togglex':{"onoff":1}}
+            return self._execute_cmd("SET", "Appliance.Control.ToggleX", payload)
+        else:
+            payload = {"channel":0,"toggle":{"onoff":1}}
+            return self._execute_cmd("SET", "Appliance.Control.Toggle", payload)
+
+    def turn_off(self):
+        if self._hwversion.split(".")[0] == "2":
+            payload = {'togglex':{"onoff":0}}
+            return self._execute_cmd("SET", "Appliance.Control.ToggleX", payload)
+        else:
+            payload = {"channel":0,"toggle":{"onoff":1}}
+            return self._execute_cmd("SET", "Appliance.Control.Toggle", payload)
 
 class Mss425e(Device):
     # TODO Implement for all channels

--- a/meross_iot/supported_devices/power_plugs.py
+++ b/meross_iot/supported_devices/power_plugs.py
@@ -362,7 +362,7 @@ class Mss310(Device):
             payload = {'togglex':{"onoff":0}}
             return self._execute_cmd("SET", "Appliance.Control.ToggleX", payload)
         else:
-            payload = {"channel":0,"toggle":{"onoff":1}}
+            payload = {"channel":0,"toggle":{"onoff":0}}
             return self._execute_cmd("SET", "Appliance.Control.Toggle", payload)
 
 class Mss425e(Device):


### PR DESCRIPTION
Hi,

I have **mss310** sockets with hardware version **2.0.0**
The payload is not the same as for versions **1.0.0**.
For 1.0.0
```
payload = {"channel":0,"toggle":{"onoff":1}}
return self._execute_cmd("SET", "Appliance.Control.Toggle", payload)
```
For 2.0.0
```
payload = {'togglex':{"onoff":1}}
return self._execute_cmd("SET", "Appliance.Control.ToggleX", payload)
```
So I added the information in the Device class to test the hardware version in `turn_on()` and `turn_off()` functions.

I also added this informations for future use:
_devName, deviceType, fmwareVersion_