### PR TITLE
Add MSS210 plug support

### DIFF
--- a/meross_iot/device_factory.py
+++ b/meross_iot/device_factory.py
@@ -1,4 +1,4 @@
-from meross_iot.supported_devices.power_plugs import Mss310, Mss110, Mss425e
+from meross_iot.supported_devices.power_plugs import Mss310, Mss210, Mss110, Mss425e
 
 def build_wrapper(
         token,
@@ -9,6 +9,8 @@ def build_wrapper(
 ):
     if device_type.lower() == "mss310":
         return Mss310(token, key, user_id,**device_specs)
+    elif device_type.lower() == "mss210":
+        return Mss210(token, key, user_id,**device_specs)
     elif device_type.lower() == "mss110":
         return Mss110(token, key, user_id,**device_specs)
     elif device_type.lower() == "mss425e":

--- a/meross_iot/supported_devices/power_plugs.py
+++ b/meross_iot/supported_devices/power_plugs.py
@@ -341,7 +341,7 @@ class Device:
         self._status = False
         payload = {"channel":0,"toggle":{"onoff":0}}
         return self._execute_cmd("SET", "Appliance.Control.Toggle", payload)
-      
+
 class Mss310(Device):
     def get_power_consumptionX(self):
         return self._execute_cmd("GET", "Appliance.Control.ConsumptionX", {})
@@ -395,6 +395,9 @@ class Mss425e(Device):
 
     def disable_usb(self):
         return self.turn_off_channel(4)
+
+class Mss210(Device):
+    pass
 
 class Mss110(Device):
     pass

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,10 @@ setup(
               'Programming Language :: Python :: 3',
               'Operating System :: OS Independent'
     ],
-    description='A simple library to deal with Meross devices. At the moment MSS110, MSS310 smart plugs and the MSS425E power stirp',
+    description='A simple library to deal with Meross devices. At the moment MSS110, MSS210, MSS310 smart plugs and the MSS425E power strip',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    keywords='meross smartplug iot mqtt domotic switch mss310 mss110 mss425e',
+    keywords='meross smartplug iot mqtt domotic switch mss310 mss210 mss110 mss425e',
     project_urls={
     'Documentation': 'https://github.com/albertogeniola/MerossIot',
     'Funding': 'https://donate.pypi.org',


### PR DESCRIPTION
Tested extensively with multiple MSS210 (EU) plugs. FW version on plugs is 1.1.12
All methods from demo work except for get_abilities(), get_power_consumptionX(), get_electricity(). The plug hardware has no ability to track power consumption data.