### PR TITLE
Modify behaviour to allow use with local mqtt server

### DIFF
--- a/meross_iot/supported_devices/power_plugs.py
+++ b/meross_iot/supported_devices/power_plugs.py
@@ -112,6 +112,10 @@ class Device:
         if "hdwareVersion" in kwords:
             self._hwversion = kwords['hdwareVersion']
 
+        # Lookup port and certificate for MQTT server
+        self._port = kwords.get('port', Device._port)
+        self._ca_cert = kwords.get('ca_cert', None)
+
         self._generate_client_and_app_id()
 
         # Password is calculated as the MD5 of USERID concatenated with KEY
@@ -128,8 +132,12 @@ class Device:
         self._mqtt_client.on_disconnect = self._on_disconnect
         self._mqtt_client.on_subscribe = self._on_subscribe
         self._mqtt_client.on_log = self._on_log
-        self._mqtt_client.username_pw_set(username=self._user_id, password=hashed_password)
-        self._mqtt_client.tls_set(ca_certs=None, certfile=None, keyfile=None, cert_reqs=ssl.CERT_REQUIRED,
+        # Avoid login if user_id is None
+        if self._user_id is not None:
+            self._mqtt_client.username_pw_set(username=self._user_id,
+                                              password=hashed_password)
+        self._mqtt_client.tls_set(ca_certs=self._ca_cert, certfile=None,
+                                  keyfile=None, cert_reqs=ssl.CERT_REQUIRED,
                                   tls_version=ssl.PROTOCOL_TLS,
                                   ciphers=None)
 


### PR DESCRIPTION
Allow port and ca_certs file to be passed in
Don't login if user_id is None