### PR TITLE
quick fix for controlling brightness with mss560m

### DIFF
--- a/meross_iot/cloud/devices/light_bulbs.py
+++ b/meross_iot/cloud/devices/light_bulbs.py
@@ -180,6 +180,16 @@ class GenericBulb(AbstractMerossDevice):
                 'temperature': temperature
             }
         }
+        
+        # handle mss560m differently
+        if self.type.lower() == 'mss560m':
+            pl = {
+                'light': self.get_light_color()
+            }
+            pl['light']['channel'] = channel
+            pl['light']['luminance'] = luminance
+            payload = pl
+
         self.execute_command(command='SET', namespace=LIGHT, payload=payload)
 
     def get_light_color(self, channel=0):


### PR DESCRIPTION
Not sure if this is the best way to solve this problem.
Controlling the brightness on mss560m was broken since the payload for mss560m is not like other "light" devices. 

Things I had to change to get the payload to not return an error saying "not supported" was to change the capacity to the correct value, change rgb value to -1 from default None, change temperature to -1 from default 100, get rid of the field 'gradual' 

Quick fix was to grab the last known status payload for the light control and modify the luminance that way. 

I tested it with my mss560m and it works and it should not affect any other device. 