### PR TITLE
FIX: Actually set the switch state in the event

### DIFF
--- a/meross_iot/meross_event.py
+++ b/meross_iot/meross_event.py
@@ -56,6 +56,7 @@ class DeviceSwitchStatusEvent(MerossEvent):
         super(DeviceSwitchStatusEvent, self).__init__(MerossEventType.DEVICE_SWITCH_STATUS)
         self.device = dev
         self.channel_id = channel_id
+        self.switch_state = switch_state
         self.generated_by_myself = generated_by_myself
 
 


### PR DESCRIPTION
@albertogeniola I'm not sure if this was done on purpose, but hereby a PR to resolve the issue.

I'm currently updating my HomeAssistant custom component and I kinda need the new state of the switch, since that is a lot cheaper than doing an actual call to the server. Like, almost instant between clicking in the app and seeing it in HomeAssistant.