### PR TITLE
Fix multi hub issue

### DIFF
--- a/meross_iot/cloud/device.py
+++ b/meross_iot/cloud/device.py
@@ -11,7 +11,7 @@ from meross_iot.meross_event import DeviceOnlineStatusEvent, DeviceBindEvent, De
 class AbstractMerossDevice(ABC):
     # Device status + lock to protect concurrent access
     _state_lock = None
-    online = False
+    online = None
 
     # Device info and connection parameters
     uuid = None
@@ -36,6 +36,7 @@ class AbstractMerossDevice(ABC):
         self._state_lock = RLock()
         self.__event_handlers_lock = RLock()
         self.__event_handlers = []
+        self.online = False
 
         self.uuid = device_uuid
 

--- a/meross_iot/cloud/devices/hubs.py
+++ b/meross_iot/cloud/devices/hubs.py
@@ -7,13 +7,11 @@ from meross_iot.logger import HUB_LOGGER as l
 
 
 class GenericHub(AbstractMerossDevice):
-    # Handles the state of this specific HUB
-    _state = {}
-    _sub_devices = {}
-    _subdev_lock = None
 
     def __init__(self, cloud_client, device_uuid, **kwords):
         super(GenericHub, self).__init__(cloud_client, device_uuid, **kwords)
+        self._state = {}
+        self._sub_devices = {}
         self._subdev_lock = RLock()
 
     def register_sub_device(self,
@@ -52,6 +50,7 @@ class GenericHub(AbstractMerossDevice):
             subdevice_id = data.get('id')
             target = self._sub_devices.get(subdevice_id)
             if target is None:
+                l.warn("dispatch_to_subdevice: no target found; data = %s, _sub_devices = %s" % (data, self._sub_devices))
                 return
 
             # Remove the id from the data payload as it will be stored as raw state from the device handler

--- a/meross_iot/manager.py
+++ b/meross_iot/manager.py
@@ -217,7 +217,6 @@ class MerossManager(object):
                     device = build_wrapper(device_type=d_type, device_uuid=d_id,
                                            cloud_client=self._cloud_client, device_specs=dev)
                     self._devices[device_id] = device
-                    l.debug("new device was added to the list: %s (%s)" % (device.name, hex(id(device))))
             is_subdevice = False
 
         elif 'subDeviceType' in dev and 'subDeviceId' in dev:
@@ -230,7 +229,6 @@ class MerossManager(object):
                     device = build_subdevice_wrapper(device_type=d_type, device_id=d_id, parent_hub=parent_hub,
                                                      cloud_client=self._cloud_client, device_specs=dev)
                     self._devices[device_id] = device
-                    l.debug("new device was added to the list: %s (%s)" % (device.name, hex(id(device))))
             is_subdevice = True
 
         else:


### PR DESCRIPTION
Hi Alberto,
I found out that the Meross library does not work correctly when multiple hubs are in use.
This is because some variables in hubs.py were declared as static variables instead of instance variables. 
While debugging this problem, I also found another issue: Every 30 seconds during device discovery, new instances of all devices were created. Apart from the unnecessary overhead, this causes the _raw_state of thermostats got "lost"
If you agree with my fixes, please merge the pull request 