### PR TITLE
With Python3, device abilities have empty dict instead of None

### DIFF
--- a/meross_iot/device_factory.py
+++ b/meross_iot/device_factory.py
@@ -104,7 +104,7 @@ def _build_cached_type(type_string: str, device_abilities: dict, base_class: typ
 
         # Check if for this ability the device exposes the X version
         x_version_ability_key = device_abilities.get(f"{key}X")
-        if x_version_ability_key is not None:
+        if x_version_ability_key:
             clsx = _ABILITY_MATRIX.get(x_version_ability_key)
 
         # Now, if we have both the clsx and the cls, prefer the clsx, otherwise go for the cls


### PR DESCRIPTION
This addresses #117 . It seems that on Python3, the device abilities contain an empty dict instead of `None`. So I changed the check to check for an empty value, not `None` specifically. The change works for me.