### PR TITLE
Fix the valve example to actually set the target temperature

### DIFF
--- a/examples/valve.py
+++ b/examples/valve.py
@@ -47,6 +47,7 @@ async def main():
         # Randomly choose a temperature between min and max
         new_temp = randint(dev.min_supported_temperature, dev.max_supported_temperature)
         print(f"Setting target temperature to {new_temp}")
+        await dev.async_set_target_temperature(new_temp)
 
     # Close the manager and logout from http_api
     manager.close()


### PR DESCRIPTION
The valve.py example script picks a random value for a new temperature, says it's setting it and then exits. Update the example to actually set the new value.
