### PR TITLE
Support for MSH300HK and MS100F

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ The list of tested devices is the following:
 - MSG100 (Garage opener)
 - MSG200 (3-doors Garage opener)
 - MSH300 (Smart hub + valve thermostat)
+- MSH300HK (Smart Hub)
 - MS100 (Smart hub + temperature/humidity sensor)
+- MS100F (temperature/humidity sensor)
 - MSS710
 - MSXH0 (Smart Humidifier)
 

--- a/meross_iot/device_factory.py
+++ b/meross_iot/device_factory.py
@@ -27,7 +27,8 @@ _LOGGER = logging.getLogger(__name__)
 
 _KNOWN_DEV_TYPES_CLASSES = {
     "mts100v3": Mts100v3Valve,
-    "ms100": Ms100Sensor
+    "ms100": Ms100Sensor,
+    "ms100f": Ms100Sensor
 }
 
 _ABILITY_MATRIX = {
@@ -85,7 +86,8 @@ _ABILITY_MATRIX = {
 
 _SUBDEVICE_MAPPING = {
     "mts100v3": Mts100v3Valve,
-    "ms100": Ms100Sensor
+    "ms100": Ms100Sensor,
+    "ms100f": Ms100Sensor
 }
 
 _dynamic_types = {}
@@ -187,12 +189,12 @@ def build_meross_device_from_abilities(http_device_info: HttpDeviceInfo,
         # - HubMerossDevice: to be used when dealing with Hubs.
         # Unfortunately, it's not clear how we should discriminate an hub from a non-hub.
         # The current implementation decides which base class to use by looking at the presence
-        # of 'Appliance.Digest.Hub' namespace within the exposed abilities.
-        discriminating_ability = Namespace.SYSTEM_DIGEST_HUB.value
+        # of 'Appliance.Digest.Hub' or 'Appliance.Hub.SubdeviceList' namespaces within the exposed abilities.
+        discriminating_abilities = [Namespace.SYSTEM_DIGEST_HUB.value, Namespace.HUB_SUBDEVICELIST.value]
         base_class = BaseDevice
-        if discriminating_ability in device_abilities:
+        if any (da in device_abilities for da in discriminating_abilities):
             _LOGGER.warning(f"Device {http_device_info.dev_name} ({http_device_info.device_type}, "
-                            f"uuid {http_device_info.uuid}) reported ability {discriminating_ability}. "
+                            f"uuid {http_device_info.uuid}) reported one ability of {discriminating_abilities}. "
                             f"Assuming this is a full-featured HUB.")
             base_class = HubDevice
 

--- a/meross_iot/model/enums.py
+++ b/meross_iot/model/enums.py
@@ -122,6 +122,7 @@ class Namespace(Enum):
     HUB_BATTERY = 'Appliance.Hub.Battery'
     HUB_TOGGLEX = 'Appliance.Hub.ToggleX'
     HUB_ONLINE = 'Appliance.Hub.Online'
+    HUB_SUBDEVICELIST = 'Appliance.Hub.SubdeviceList'
 
     # SENSORS
     HUB_SENSOR_ALL = 'Appliance.Hub.Sensor.All'


### PR DESCRIPTION
Hello,

This should close #373 

MSH300HK hub is not supported. For what I can see, hubs are detected via the ability `Appliance.Digest.Hub`. However, the msh300hk does not expose this one. As proposed in #309 I choose to add a test for the `Appliance.Hub.SubdeviceList` ability. I do not have a MSH300 to check if it's also available in this hub.

The MS100F temperature & humidity sensor seems to behave like the MS100. So I just added it in the `_KNOWN_DEV_TYPES_CLASSES` and `_SUBDEVICE_MAPPING` dicts.

Please feel free to ask if you need me to update something for the PR to be merged.

Best regards
Jérôme
