### PR TITLE
Add setuptools to requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ pytest-aiohttp==0.3.0
 pytest-custom_exit_code==0.3.0
 proxy.py==2.3.1
 pysocks==1.7.1
+setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ paho-mqtt>=1.5.0,<2.0.0
 requests>=2.19.1,<3.0.0
 aiohttp[speedups]>=3.7.4.post0,<4.0.0
 pycryptodomex>=3.20.0
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
         'paho-mqtt>=1.5.0,<2.0.0',
         'requests>=2.19.1,<3.0.0',
         'aiohttp[speedups]>=3.7.4.post0,<4.0.0',
-        'pycryptodomex>=3.20.0'
+        'pycryptodomex>=3.20.0',
+        'setuptools',
     ],
     python_requires='>=3.7',
     test_suite='tests',


### PR DESCRIPTION
When importing the library I consistently see the following stack trace:
```
Traceback (most recent call last):
  File "/home/matthew/Code/meross-auto-lighting/.venv/bin/meross-auto-lighting", line 5, in <module>
    from meross_auto_lighting import main
  File "/home/matthew/Code/meross-auto-lighting/meross_auto_lighting.py", line 8, in <module>
    from meross_iot.http_api import MerossHttpClient
  File "/home/matthew/Code/meross-auto-lighting/.venv/lib/python3.12/site-packages/meross_iot/http_api.py", line 25, in <module>
    from meross_iot.utilities.misc import current_version
  File "/home/matthew/Code/meross-auto-lighting/.venv/lib/python3.12/site-packages/meross_iot/utilities/misc.py", line 1, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```
Modern `setuptools` provides this import [as specified here](https://stackoverflow.com/a/10538412/2132312) so I've added it to the package requirements.