### PR TITLE
ThermostatModeBState: support 0 as NOT_HEATING_COOLING

### DIFF
--- a/meross_iot/model/enums.py
+++ b/meross_iot/model/enums.py
@@ -61,8 +61,9 @@ class ThermostatWorkingMode(Enum):
 
 
 class ThermostatModeBState(Enum):
+    NOT_HEATING_COOLING = 0
     HEATING_COOLING = 1
-    NOT_HEATING_COOLING = 2
+    NOT_HEATING_COOLING_LEGACY = 2
 
 
 class RollerShutterState(Enum):


### PR DESCRIPTION
My 10 pieces of MTS200 return 0 for the NOT_HEATING_COOLING Bstate.
I don't know where the 2 comes from, maybe legacy.