### PR TITLE
Update light to handle MRS100

### DIFF
--- a/meross_iot/controller/mixins/light.py
+++ b/meross_iot/controller/mixins/light.py
@@ -56,13 +56,18 @@ class LightMixin(object):
         _LOGGER.debug(f"Handling {self.__class__.__name__} mixin data update.")
         locally_handled = False
         if namespace == Namespace.SYSTEM_ALL:
-            light_data = data.get('all', {}).get('digest', {}).get('light', [])
-            self._update_channel_status(channel=light_data.get('channel'),
-                                        rgb=light_data.get('rgb'),
-                                        luminance=light_data.get('luminance'),
-                                        temperature=light_data.get('temperature'),
-                                        onoff=light_data.get('onoff'))
-            locally_handled = True
+            digest_data = data.get('all', {}).get('digest', {})
+            #On device MRS100 it reports as Handle Light but has no light data then digest is empty
+            if digest_data.has_key(light):
+                light_data = digest_data.get('light', [])
+                self._update_channel_status(channel=light_data.get('channel'),
+                                            rgb=light_data.get('rgb'),
+                                            luminance=light_data.get('luminance'),
+                                            temperature=light_data.get('temperature'),
+                                            onoff=light_data.get('onoff'))
+                locally_handled = True
+            else:
+                _LOGGER.debug(f"Device has no light value in data:{data}")
         super_handled = await super().async_handle_update(namespace=namespace, data=data)
         return super_handled or locally_handled
 


### PR DESCRIPTION
On device MRS100 it reports as Handle Light but has no light data then digest is empty We test if digest has key light before gathering data


Data received is : 
```
Received message from topic /app/2876630-43ababbc1cc8a332cc2188f9902c6779/subscribe: b'{
	"header": {
		"messageId": "f589abcb7536a53ae15fa288dba2b3ad",
		"namespace": "Appliance.System.All",
		"triggerSrc": "Android",
		"method": "GETACK",
		"payloadVersion": 1,
		"from": "/appliance/2211013555341970080148e1e9aeb62a/publish",
		"uuid": "2211013555341970080148e1e9aeb62a",
		"timestamp": 1773903089,
		"timestampMs": 299,
		"sign": "fab44bf26f90f51b333c22b8e816a26c"
	},
	"payload": {
		"all": {
			"system": {
				"hardware": {
					"type": "mrs100",
					"subType": "un",
					"version": "7.0.0",
					"chipType": "rtl8710cm",
					"uuid": "2211013555341970080148e1e9aeb62a",
					"macAddress": "48:e1:e9:ae:b6:2a"
				},
				"firmware": {
					"version": "7.6.20",
					"homekitVersion": "6.3",
					"compileTime": "2025/12/08-18:16:09",
					"encrypt": 1,
					"wifiMac": "3a:07:16:e8:a6:00",
					"innerIp": "192.168.1.79",
					"server": "mqtt-eu-4.meross.com",
					"port": 443,
					"userId": 2876630
				},
				"time": {
					"timestamp": 1773903089,
					"timezone": "Europe/Paris",
					"timeRule": [
						[
							1679792400,
							7200,
							1
						],
						[
							1698541200,
							3600,
							0
						],
						[
							1711846800,
							7200,
							1
						],
						[
							1729990800,
							3600,
							0
						],
						[
							1743296400,
							7200,
							1
						],
						[
							1761440400,
							3600,
							0
						],
						[
							1774746000,
							7200,
							1
						],
						[
							1792890000,
							3600,
							0
						],
						[
							1806195600,
							7200,
							1
						],
						[
							1824944400,
							3600,
							0
						],
						[
							1837645200,
							7200,
							1
						],
						[
							1856394000,
							3600,
							0
						],
						[
							1869094800,
							7200,
							1
						],
						[
							1887843600,
							3600,
							0
						],
						[
							1901149200,
							7200,
							1
						],
						[
							1919293200,
							3600,
							0
						],
						[
							1932598800,
							7200,
							1
						],
						[
							1950742800,
							3600,
							0
						],
						[
							1964048400,
							7200,
							1
						],
						[
							1982797200,
							3600,
							0
						]
					]
				},
				"online": {
					"status": 1,
					"bindId": "vw44MizgGEQWwSh6",
					"who": 1
				}
			},
			"digest": {}
		}
	}
}'
```