### PR TITLE
Fix AttributeError when digest 'light' field is a list

### DIFF
--- a/meross_iot/controller/mixins/light.py
+++ b/meross_iot/controller/mixins/light.py
@@ -56,12 +56,15 @@ class LightMixin(object):
         _LOGGER.debug(f"Handling {self.__class__.__name__} mixin data update.")
         locally_handled = False
         if namespace == Namespace.SYSTEM_ALL:
-            light_data = data.get('all', {}).get('digest', {}).get('light', [])
-            self._update_channel_status(channel=light_data.get('channel'),
-                                        rgb=light_data.get('rgb'),
-                                        luminance=light_data.get('luminance'),
-                                        temperature=light_data.get('temperature'),
-                                        onoff=light_data.get('onoff'))
+            light_data = data.get('all', {}).get('digest', {}).get('light', {})
+            if isinstance(light_data, list):
+                light_data = light_data[0] if light_data else {}
+            if light_data:
+                self._update_channel_status(channel=light_data.get('channel'),
+                                            rgb=light_data.get('rgb'),
+                                            luminance=light_data.get('luminance'),
+                                            temperature=light_data.get('temperature'),
+                                            onoff=light_data.get('onoff'))
             locally_handled = True
         super_handled = await super().async_handle_update(namespace=namespace, data=data)
         return super_handled or locally_handled


### PR DESCRIPTION
Devices without light capability (e.g. mrs100 roller shutters) can report
`digest.light` as an empty list `[]` instead of omitting the key.
`LightMixin.async_handle_update` then called `.get('channel')` on that
list, raising:

    AttributeError: 'list' object has no attribute 'get'

on every full state update (`SYSTEM_ALL`), which aborted the device
update entirely and left the entity unavailable in Home Assistant.

This normalizes list values before use and skips the light-status
update when there is no actual light data.

Reproduced on mrs100, HW 7.0.0, FW 7.6.20.
Related: albertogeniola/meross-homeassistant#586
